### PR TITLE
Update common.fr.json

### DIFF
--- a/src/assets/translations/common.fr.json
+++ b/src/assets/translations/common.fr.json
@@ -8,7 +8,7 @@
     "submenu": {
       "introduction": "Présentation",
       "next": "Prochaine Bicyclette milonga",
-      "schedule": "Toute les dates 24-25",
+      "schedule": "Toute les dates 25-26",
       "location": "L'adresse",
       "newsletter": "Newsletter"
     },
@@ -16,7 +16,7 @@
     "dateTime": "le {{starts, datetime}} jusqu'à {{ends, datetime}}",
     "subtitle": "Bienvenue ! Notre équipe de cyclistes survoltés t'attend dans la salle TRAC en plein cœur du Toulouse historique, avec son plancher en chêne et sa sono incroyable. Des djs invités 100% tradis, de la nourriture maison concoctée par nos chef.fe.s, et des jeux potaches. PAF : 10€ ou 8€ si besoin",
     "description": "Notre prochain.e dj invité.e !",
-    "plan": "Toute la saison 24-25",
+    "plan": "Toute la saison 25-26",
     "newsletter": "Inscris-toi à la newsletter pour avoir toutes les infos"
   },
   "marathon": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Localization
  * Updated French translations to reflect the 2025–2026 season: the schedule submenu and the plan view now display “Toutes les dates 25–26” and “Toute la saison 25–26.”
  * French-speaking users will see current season labels across the relevant menus and pages.
  * No structural changes to translations; only visible text updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->