### PR TITLE
content(marathon): shift Saturday city tour to 10h-12h

### DIFF
--- a/src/assets/translations/common.en.json
+++ b/src/assets/translations/common.en.json
@@ -82,7 +82,7 @@
         "title": "Saturday",
         "inner": [
           {
-            "time": "11-13AM",
+            "time": "10AM-12PM",
             "description": "WALKS in Toulouse."
           },
           {

--- a/src/assets/translations/common.en.json
+++ b/src/assets/translations/common.en.json
@@ -107,11 +107,11 @@
         "title": "Sunday",
         "inner": [
           {
-            "time": "11AM -1PM",
+            "time": "11AM-1PM",
             "description": "WORKSHOP."
           },
           {
-            "time": "11AM -2PM",
+            "time": "11AM-2PM",
             "description": "SET A SUNDAY BIKE RIDE - TDJ Nicolas Arribat (Toulouse)"
           },
           {

--- a/src/assets/translations/common.es.json
+++ b/src/assets/translations/common.es.json
@@ -77,7 +77,7 @@
         "title": "Sábado",
         "inner": [
           {
-            "time": "11h-13h",
+            "time": "10h-12h",
             "description": "PASEOS en Toulouse."
           },
           {

--- a/src/assets/translations/common.fr.json
+++ b/src/assets/translations/common.fr.json
@@ -82,7 +82,7 @@
         "title": "Samedi",
         "inner": [
           {
-            "time": "11h-13h",
+            "time": "10h-12h",
             "description": "Balade dans Toulouse."
           },
           {

--- a/src/assets/translations/marathons.en.json
+++ b/src/assets/translations/marathons.en.json
@@ -77,7 +77,7 @@
             "description": "ALEXANDER TECHNICAL WORKSHOP with Élodie and Maïté, meet 10am in front of Salle Trac, free admission."
           },
           {
-            "time": "10AM -2PM",
+            "time": "10AM-2PM",
             "description": "SET A SUNDAY BIKE RIDE - TDJ Nicolas Arribat (Toulouse)"
           },
           {


### PR DESCRIPTION
## Summary

- Move the Saturday city tour slot (Balade dans Toulouse / WALKS in Toulouse / PASEOS en Toulouse) from **11h-13h** to **10h-12h**.
- Updates all three translation files: `common.en.json`, `common.fr.json`, `common.es.json`.

## Rationale

Requested timing change for the marathon city tour: start at 10h instead of 11h, ending at 12h.