### PR TITLE
Add milonga dates for the 2026/2027 season

### DIFF
--- a/src/app/[lang]/data.ts
+++ b/src/app/[lang]/data.ts
@@ -59,4 +59,44 @@ export const milongaDates = [
     starts: new Date(2026, 5, 28, 19, 15, 0),
     ends: new Date(2026, 5, 29, 1, 30, 0),
   },
+  {
+    starts: new Date(2026, 8, 12, 19, 15, 0),
+    ends: new Date(2026, 8, 13, 1, 30, 0),
+  },
+  {
+    starts: new Date(2026, 9, 17, 19, 15, 0),
+    ends: new Date(2026, 9, 18, 1, 30, 0),
+  },
+  {
+    starts: new Date(2026, 10, 7, 19, 15, 0),
+    ends: new Date(2026, 10, 8, 1, 30, 0),
+  },
+  {
+    starts: new Date(2026, 11, 5, 19, 15, 0),
+    ends: new Date(2026, 11, 6, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 0, 9, 19, 15, 0),
+    ends: new Date(2027, 0, 10, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 1, 6, 19, 15, 0),
+    ends: new Date(2027, 1, 7, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 2, 13, 19, 15, 0),
+    ends: new Date(2027, 2, 14, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 3, 10, 19, 15, 0),
+    ends: new Date(2027, 3, 11, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 4, 1, 19, 15, 0),
+    ends: new Date(2027, 4, 2, 1, 30, 0),
+  },
+  {
+    starts: new Date(2027, 5, 12, 19, 15, 0),
+    ends: new Date(2027, 5, 13, 1, 30, 0),
+  },
 ];


### PR DESCRIPTION
## Summary
Adds 10 new milonga dates for the 2026/2027 season to `src/app/[lang]/data.ts`.

| Date | Year |
|---|---|
| 12 sept | 2026 |
| 17 oct | 2026 |
| 7 nov | 2026 |
| 5 déc | 2026 |
| 9 jan | 2027 |
| 6 fév | 2027 |
| 13 mar | 2027 |
| 10 avr | 2027 |
| 1er mai | 2027 |
| 12 juin | 2027 |

Each event uses the current established time pattern (starts 19:15, ends 01:30 next day), consistent with all recent entries.

## Test plan
- [x] `tsc --noEmit` passes (exit 0)