### PR TITLE
Update 2026-2027 milonga schedule

### DIFF
--- a/src/app/[lang]/data.ts
+++ b/src/app/[lang]/data.ts
@@ -76,8 +76,8 @@ export const milongaDates = [
     ends: new Date(2026, 11, 6, 1, 30, 0),
   },
   {
-    starts: new Date(2027, 0, 9, 19, 15, 0),
-    ends: new Date(2027, 0, 10, 1, 30, 0),
+    starts: new Date(2027, 0, 3, 19, 15, 0),
+    ends: new Date(2027, 0, 4, 1, 30, 0),
   },
   {
     starts: new Date(2027, 1, 6, 19, 15, 0),
@@ -88,12 +88,12 @@ export const milongaDates = [
     ends: new Date(2027, 2, 14, 1, 30, 0),
   },
   {
-    starts: new Date(2027, 3, 10, 19, 15, 0),
-    ends: new Date(2027, 3, 11, 1, 30, 0),
+    starts: new Date(2027, 3, 11, 19, 15, 0),
+    ends: new Date(2027, 3, 12, 1, 30, 0),
   },
   {
-    starts: new Date(2027, 4, 1, 19, 15, 0),
-    ends: new Date(2027, 4, 2, 1, 30, 0),
+    starts: new Date(2027, 4, 9, 19, 15, 0),
+    ends: new Date(2027, 4, 10, 1, 30, 0),
   },
   {
     starts: new Date(2027, 5, 12, 19, 15, 0),


### PR DESCRIPTION
## Summary

Updates the 2026–2027 milonga season schedule in `src/app/[lang]/data.ts` to match the confirmed dates:

| Month | Date |
|-------|------|
| Samedi | 12 sept 2026 |
| Samedi | 17 oct 2026 |
| Samedi | 7 nov 2026 |
| Samedi | 5 déc 2026 |
| **Dimanche** | **3 janv 2027** |
| Samedi | 6 fév 2027 |
| Samedi | 13 mars 2027 |
| **Dimanche** | **11 avr 2027** |
| **Dimanche** | **9 mai 2027** |
| Samedi | 12 juin 2027 |

Most dates already matched the existing data. Three were adjusted (all moved to Sundays):

- **January:** 9 → 3
- **April:** 10 → 11
- **May:** 1 → 9

Start/end times (19:15 → 01:30) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NL887TosswgVj3xStKpZTH)_